### PR TITLE
Increase timeout in set_docker_client function

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -61,7 +61,7 @@ def get_docker_client(host='local'):
         _docker_clients[host] = client
     return _docker_clients[host]
 
-def set_docker_client(host='local', timeout=5):
+def set_docker_client(host='local', timeout=30):
     try:
         if host == 'local':
             logger.debug("Connecting to local Docker engine...")


### PR DESCRIPTION
Increased the timeout parameter for set_docker_client function from 5 to 30 seconds. 

Addresses issue #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Docker client connection timeout from 5 to 30 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->